### PR TITLE
5/ZK-HUMAN-VERIFICATION: Update spec with implementation findings

### DIFF
--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -420,6 +420,52 @@ Implementations SHOULD provide test vectors for:
 - signature verification inputs,
 - SMT non-inclusion proof generation and verification.
 
+## User Experience Guidelines
+
+The verification flow involves sensitive credential operations. Implementations SHOULD follow these guidelines to ensure users can make informed decisions about their data.
+
+### Privacy Communication
+
+The UI MUST clearly communicate the following at each stage of the flow:
+
+1. **What the user is verifying.** The user is using a government-issued certificate to verify eligibility for a forum badge. The specific eligibility condition (e.g., possession of a valid certificate from a trusted issuer) SHOULD be stated in plain language.
+2. **What stays on the device.** The full certificate data, PIN, and private key material never leave the device. Revocation status is checked locally. The UI MUST state this explicitly before and during proof generation.
+3. **What is sent to the verifier.** Only the public inputs required for verification (nullifier, challenge, revocation root, CA public key commitment, and the proof) are submitted. The UI SHOULD list these in user-facing terms (e.g., "information needed to confirm your eligibility") with raw field names available under a collapsed technical details section.
+4. **What is not sent.** Full certificate data, PIN, and raw personal identity details are not transmitted. The UI MUST state this on the consent / confirmation screen before submission.
+
+### Consent Before Submission
+
+Implementations MUST include an explicit consent step after proof generation and before submission to the verifier. This step MUST:
+
+- confirm that verification data has been prepared locally and has not yet been sent,
+- summarize what will and will not be sent,
+- require an explicit user action (e.g., button tap) to proceed with submission.
+
+### Technical Detail Separation
+
+Raw cryptographic values, proof-system internals, backend identifiers, and protocol-level field names (e.g., circuit names, proving key names, witness states, raw public input values) SHOULD NOT appear in the main UI by default.
+
+These values SHOULD be preserved in a collapsed "technical details" section for debugging and support purposes. Users SHOULD be able to copy diagnostic information from this section when reporting errors.
+
+### Error Handling UX
+
+Error states MUST:
+
+- display a user-readable title and plain-language explanation,
+- recommend a specific next action (retry, restart, or contact support),
+- include an error code for support reference,
+- NOT expose PIN, full certificate data, or raw private key material in error output.
+
+Diagnostic information sufficient for engineering debugging (e.g., error code, failing step, timestamp, browser/OS, verifier response status) SHOULD be available under a collapsed section or via a "copy diagnostic info" action.
+
+### PIN Safety
+
+When the verification flow requires PIN entry (e.g., for smartcard-based certificate access):
+
+- the UI MUST warn users about the lockout threshold before PIN entry,
+- the UI MUST display remaining PIN attempts after each incorrect entry, and
+- the UI MUST clearly distinguish between a session-level PIN unlock and a permanent card lockout.
+
 # References
 
 - [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -28,7 +28,7 @@ This specification defines a privacy-preserving protocol that allows a user to p
 
 The protocol prevents duplicate verification via a deterministic nullifier. Off-chain verification is the deployment mode for this version. On-chain verification was evaluated and is deferred (see [On-Chain Verification Status](#on-chain-verification-status)).
 
-The proof generation pipeline builds on OpenAC ([paper](https://github.com/privacy-ethereum/zkID/blob/main/paper/zkID.pdf)), adopting a minimal profile: RSA certificate chain validation, nullifier-based duplicate prevention, and SMT-based revocation. Features such as unlinkability and device binding are not in scope for this version but MAY be incorporated in future revisions.
+The proof generation pipeline builds on OpenAC ([paper](https://github.com/privacy-ethereum/zkID/blob/main/paper/zkID.pdf)), adopting a minimal profile: RSA certificate chain validation, nullifier-based duplicate prevention, SMT-based revocation, and per-session unlinkability via blinded key commitments. The proof pipeline is split into two linked sub-circuits — a CertChain circuit for credential verification and a DeviceSig circuit for session binding and nullifier derivation.
 
 This version (v0.1) enforces one verification per certificate instance. If the certificate is periodically renewed and renewal modifies the certificate contents, the user MAY be able to verify again (known limitation).
 
@@ -102,25 +102,32 @@ Verifiers MUST provide a 256-bit `challenge` value per verification attempt.
 
 The protocol MUST output a deterministic nullifier to prevent duplicate verification.
 
-The nullifier is derived from the subject distinguished name:
+The nullifier is derived from the card's RSA signature over an application-bound message:
 
 ```
-nullifier := Poseidon( Encode(app_id || subjectDN) )
+nullifier := Poseidon( RSA_Sign_sk(app_id || subjectDN) )
 ```
 
 Where:
+- `RSA_Sign_sk` is the card's RSA signing operation using the user's private key `sk` (PKCS#1 v1.5, which is deterministic — same key + same message = same signature),
 - `app_id` is a platform identifier (domain separator),
-- `subjectDN` is the subject distinguished name extracted from the certificate. The `subjectDN` contains a secret unique identifier assigned by the issuing CA and is not publicly available information,
+- `subjectDN` is the subject distinguished name extracted from the certificate,
 - `Poseidon` is the Poseidon hash function (see [Cryptographic Primitives](#cryptographic-primitives)).
 
+The nullifier is computed in the DeviceSig circuit, not the CertChain circuit (see [Circuit Design](#circuit-design)).
+
+Because the nullifier derivation requires the card's private key, an adversary cannot compute nullifiers for targeted users even if the `subjectDN` is known. This prevents dictionary attacks against the nullifier.
+
 Each platform MUST use a unique `app_id`.
+
+A future version SHOULD add a domain-separation tag to the signed message (e.g., `"zkID-nullifier-v1" || app_id || subjectDN`) to prevent cross-protocol nullifier correlation when the same card key is used across multiple ZK protocols.
 
 ## Cryptographic Primitives
 
 This specification defines:
 
 - Hash function (data integrity): `SHA-256` for certificate TBS data hashing.
-- Hash function (nullifier): `Poseidon` hash, a ZK-friendly hash function optimized for arithmetic circuits (see [circomlib Poseidon](https://github.com/iden3/circomlib/blob/master/circuits/poseidon.circom)).
+- Hash function (nullifier, pk_commit): `Poseidon` hash over the secq256r1 scalar field, a ZK-friendly hash function optimized for arithmetic circuits. For hashing more than 3 field elements, implementations use `ChunkedPoseidonP256(N)` — a sponge construction wrapping `PoseidonP256(2)` that processes N field elements in chunks.
 - Signature verification: `RSA_Verify(PK, msg, σ) -> {0,1}` — RSA signature verification over SHA-256 hashed TBS data.
 - Sparse Merkle Tree non-inclusion: `SMT_NonInclusion(root, leaf, proof) -> {0,1}` — verifies that `leaf` is **not** present in the SMT committed to by `root` (see [PSE: Revocation in zkID](https://pse.dev/blog/revocation-in-zkid-merkle-tree-based-approaches)).
 - Encoding: `Encode()` is a deterministic canonical encoding function using base64 encoding. All implementations MUST use the same base64 encoding variant (standard alphabet, with padding) to ensure consistent nullifier derivation across verifiers.
@@ -131,14 +138,16 @@ Concatenation MUST be length-prefixed (e.g., `len(x)||x||len(y)||y||...`) to avo
 
 ### RSA
 
-- Key size: RSA-2048
+- Issuer CA key size: RSA-2048 or RSA-4096 (depending on certificate generation)
+- User key size: RSA-2048
 - Padding scheme: PKCS#1 v1.5
 - Hash algorithm: SHA-256
+- Maximum certificate length: 1536 bytes (24 SHA-256 blocks)
 
 ### Poseidon Hash
 
-- Implementation: [circomlib Poseidon](https://github.com/iden3/circomlib/blob/master/circuits/poseidon.circom)
-- Field: BN254 scalar field
+- Implementation: Poseidon over the secq256r1 scalar field (P-256 companion curve).
+- Implementations MUST use round constants generated for the secq256r1 field.
 - Implementations MUST use consistent round parameters (t, number of full/partial rounds) across all parties.
 
 ### Proving System
@@ -153,85 +162,186 @@ Implementations MUST:
 
 1. Obtain `challenge`, `app_id`, and the current `revocation_root` from the verifier context.
 2. Download the SMT snapshot and generate the revocation non-inclusion witness locally (see [Witness Retrieval](#witness-retrieval)). Verify that the locally computed root matches the published `revocation_root`.
-3. Construct circuit inputs from the certificate `S`, RSA signature `σ`, trusted CA public keys, and the locally generated revocation witness.
-4. Generate a proof for the statement in [Circuit Design](#circuit-design).
-5. Submit the proof and public inputs to the verifier.
+3. Generate fresh `pk_blind` (248-bit randomness) for this session.
+4. Sign the TBS data (containing `app_id || subjectDN`) with the card's RSA key to obtain `σ_device`.
+5. Construct CertChain circuit inputs from the certificate `S`, issuer CA signature `σ`, user public key, `pk_blind`, and the locally generated revocation witness.
+6. Construct DeviceSig circuit inputs from the TBS data, `σ_device`, user public key, `pk_blind`, and the `challenge`.
+7. Generate proofs for both circuits (see [Circuit Design](#circuit-design)).
+8. Submit both proofs and their public inputs to the verifier.
 
 ## Circuit Design
 
-### Private Inputs
+The proof pipeline is split into two linked sub-circuits: a **CertChain** circuit for credential verification and a **DeviceSig** circuit for session binding and nullifier derivation.
+
+### Relation Split
+
+Implementations MUST realize the proof pipeline as two linked circuits:
+
+1. **CertChain**: Verifies the certificate chain, checks revocation non-inclusion, extracts identity fields, and computes a blinded key commitment (`pk_commit`).
+2. **DeviceSig**: Verifies the card's RSA signature over the session TBS data, derives the nullifier, binds to the session challenge and `app_id`, and computes the same `pk_commit`.
+
+The two circuits are linked via `pk_commit`:
+
+```
+pk_commit := ChunkedPoseidonP256(user_pk_limbs[0..k] || pk_blind)
+```
+
+Where:
+- `user_pk_limbs` are the limbs of the user's RSA-2048 public key (`k=17` limbs),
+- `pk_blind` is fresh 248-bit randomness generated per session.
+
+Both circuits MUST compute `pk_commit` identically. The verifier MUST assert that the `pk_commit` from the CertChain proof equals the `pk_commit` from the DeviceSig proof.
+
+`pk_blind` provides cross-session unlinkability: even for the same user key, `pk_commit` differs across sessions, preventing the verifier from linking separate verification attempts.
+
+### Valid Configurations
+
+Exactly two configurations are supported, depending on the issuer CA key size:
+
+- **MOICA-G2**: `cert_chain_rs2048` + `device_sig_rs2048`
+- **MOICA-G3**: `cert_chain_rs4096` + `device_sig_rs2048`
+
+The DeviceSig circuit is always RSA-2048 because user keys are always RSA-2048.
+
+### CertChain Circuit
+
+#### Private Inputs
 
 - `S`: Certificate message (certificate data).
-- `σ`: RSA signature over the TBS (To-Be-Signed) data.
+- `σ`: RSA signature over the TBS (To-Be-Signed) data from the issuer CA.
 - `subjectDN`: Subject distinguished name extracted from `S`.
 - `sn`: Subject number extracted from `S`, used for revocation lookup.
-- `PK_cert`: Public key extracted from the end-entity certificate, used to verify the certificate was issued by the intermediate CA (`PK_CA`).
+- `PK_cert`: Public key extracted from the end-entity certificate.
+- `pk_blind`: Fresh 248-bit randomness for `pk_commit` blinding.
 - `revocation_witness`: SMT non-inclusion proof (Merkle path of sibling hashes) for the prover's `sn`, generated locally from a downloaded SMT snapshot (see [Witness Retrieval](#witness-retrieval)).
 
-### Public Inputs
+#### Public Inputs
 
-- `challenge: bytes32`
-- `app_id: <encoded string>`
-- `nullifier: bytes32`
-- `PK_CA`: Trusted CA public key from intermediate CA.
-- `revocation_root: bytes32`: Current root of the revocation Sparse Merkle Tree.
+- `pk_commit`: Blinded commitment to the user's public key.
+- `modulus[N]`: Issuer CA RSA modulus limbs (N=17 for RSA-2048, N=34 for RSA-4096).
+- `smtRoot: bytes32`: Current root of the revocation Sparse Merkle Tree.
 
-### Circuit Operations
+#### CertChain Operations
 
-The circuit MUST enforce:
+The CertChain circuit MUST enforce:
 
 1. **Certificate chain validation**
 
-Confirm that the end-entity certificate was issued by a trusted CA:
+   Confirm that the end-entity certificate was issued by a trusted CA:
 
-```
-isValid := RSA_Verify(PK_CA, TBS(S), σ)
-assert(isValid == 1)
-```
+   ```
+   isValid := RSA_Verify(issuer_modulus, TBS(S), σ)
+   assert(isValid == 1)
+   ```
 
 2. **Subject DN extraction**
 
-```
-subjectDN := ExtractSubjectDN(S)
-```
+   ```
+   subjectDN := ExtractSubjectDN(S)
+   ```
+
+3. **Serial number extraction**
+
+   ```
+   sn := ExtractSerialNumber(S)
+   ```
+
+4. **Revocation non-inclusion**
+
+   Prove the certificate has not been revoked:
+
+   ```
+   revoked_id := Poseidon( Encode(sn) )
+   assert( SMT_NonInclusion(smtRoot, revoked_id, revocation_witness) == 1 )
+   ```
+
+5. **pk_commit computation**
+
+   ```
+   pk_commit := ChunkedPoseidonP256(user_pk_limbs || pk_blind)
+   ```
+
+### DeviceSig Circuit
+
+#### Private Inputs
+
+- `TBS`: To-Be-Signed data for the device/credential signature.
+- `σ_device`: RSA signature from the user's card over the TBS data.
+- `user_pk_limbs`: Limbs of the user's RSA-2048 public key.
+- `pk_blind`: Same per-session randomness used in the CertChain circuit.
+
+#### Public Inputs
+
+- `pk_commit`: Blinded commitment to the user's public key (must match CertChain).
+- `nullifier: bytes32`: Derived from the card's RSA signature.
+- `app_id_packed`: Platform identifier packed as a single field element.
+- `challenge: bytes32`: Per-session challenge from the verifier.
+
+#### DeviceSig Operations
+
+The DeviceSig circuit MUST enforce:
+
+1. **Credential signature verification**
+
+   Verify the card's RSA signature over the TBS data:
+
+   ```
+   isValid := RSA_Verify(user_pk, TBS, σ_device)
+   assert(isValid == 1)
+   ```
+
+2. **pk_commit computation**
+
+   ```
+   pk_commit := ChunkedPoseidonP256(user_pk_limbs || pk_blind)
+   ```
+
+   This MUST produce the same value as the CertChain circuit.
 
 3. **Nullifier derivation**
 
-```
-nullifier := Poseidon( Encode(app_id || subjectDN) )
-```
+   ```
+   nullifier := Poseidon(σ_device)
+   ```
 
-4. **Challenge binding**
+4. **app_id binding**
 
-The proof MUST bind to `challenge` as a public input.
+   The `app_id` is extracted from the TBS data and packed as a single field element. The verifier MUST compare against the expected `app_id`.
 
-5. **Revocation non-inclusion**
+5. **Challenge binding**
 
-Prove the certificate has not been revoked:
-
-```
-revoked_id := Poseidon( Encode(sn) )
-assert( SMT_NonInclusion(revocation_root, revoked_id, revocation_witness) == 1 )
-```
+   The proof MUST bind to `challenge` as a public input. The circuit enforces binding via a Semaphore-style dummy square (`challengeSquared := challenge * challenge`).
 
 ### Outputs
 
-- `nullifier: bytes32`
+- `nullifier: bytes32` (from DeviceSig)
+- `pk_commit` (from both circuits, must be equal)
 
 ## Proof Output Format
 
-Implementations MUST serialize proof outputs in a deterministic format.
+Implementations MUST serialize proof outputs in a deterministic format. A complete verification submission consists of two linked proofs.
 
-A minimal proof object SHOULD include:
+A minimal proof submission object SHOULD include:
 
 ```text
 {
-  app_id: <string>,
-  challenge: bytes32,
-  nullifier: bytes32,
-  revocation_root: bytes32,
-  pk_ca: list<string>,
-  proof: bytes
+  cert_chain: {
+    proof: bytes,
+    public_inputs: {
+      pk_commit: field_element,
+      modulus: list<field_element>,
+      smt_root: bytes32
+    }
+  },
+  device_sig: {
+    proof: bytes,
+    public_inputs: {
+      pk_commit: field_element,
+      nullifier: bytes32,
+      app_id_packed: field_element,
+      challenge: bytes32
+    }
+  }
 }
 ```
 
@@ -239,10 +349,12 @@ A minimal proof object SHOULD include:
 
 ### Verifier MUST
 
-- Validate the zero-knowledge proof against the public inputs.
+- Validate both the CertChain proof and the DeviceSig proof against their respective public inputs.
+- Assert that `pk_commit` from the CertChain proof equals `pk_commit` from the DeviceSig proof (constant-time comparison).
+- Validate that `challenge` matches the session challenge issued by the verifier.
+- Validate that `app_id_packed` matches the expected platform identifier.
 - Validate challenge freshness (not expired).
-- Enforce `app_id` matches the expected policy for the verification endpoint.
-- Validate that `revocation_root` matches the latest known revocation tree root (from the CA's CRL or a trusted updater).
+- Validate that `smt_root` matches the latest known revocation tree root (from the CA's CRL or a trusted updater).
 - Check whether the nullifier has already been used and reject duplicates.
 - Persist nullifier state durably (i.e., nullifier rejection MUST survive verifier restarts).
 
@@ -277,15 +389,9 @@ Error responses MUST include:
 
 ## Certificate Renewal
 
-The nullifier is derived from `subjectDN`, which is stable across certificate renewals as long as the subject identity remains the same.
+The nullifier is derived from the card's RSA signature over `app_id || subjectDN`. If certificate renewal issues a new RSA key pair, the nullifier will change (different signing key produces a different signature). Therefore a user MAY be able to verify again after renewal if the renewal generates a new key pair.
 
-If the issuer renews/reissues certificates such that `subjectDN` changes, then the nullifier will change. Therefore a user MAY be able to verify again after renewal with a different `subjectDN`.
-
-A future version MAY derive nullifiers from a renewal-stable holder secret:
-
-```
-nullifier := Poseidon( Encode(app_id || holder_secret) )
-```
+If the renewal retains the same key pair and `subjectDN`, the nullifier remains stable.
 
 ## On-Chain Verification Status
 
@@ -356,12 +462,14 @@ For the full research details, see [Exploring Spartan2 Proofs for On-Chain Verif
 The protocol assumes:
 
 - The security of Spartan2 with Hyrax polynomial commitment scheme (transparent setup — no trusted setup required).
-- The unforgeability of the RSA signature scheme (RSA-2048, PKCS#1 v1.5) used for certificate signing.
-- Collision resistance of SHA-256 (for TBS hashing) and Poseidon (for nullifier derivation and revocation leaf computation).
+- The unforgeability of the RSA signature scheme (RSA-2048 and RSA-4096, PKCS#1 v1.5) used for certificate signing and credential signatures.
+- Collision resistance of SHA-256 (for TBS hashing) and Poseidon over secq256r1 (for nullifier derivation, pk_commit computation, and revocation leaf computation).
 - Correct and unique domain separation via `app_id`.
 - Correct canonical encoding via `Encode()` (base64, standard alphabet, with padding).
 - Freshness of the revocation SMT snapshot (i.e., the snapshot reflects the latest CRL published by the CA). The prover downloads the snapshot locally and verifies the computed root against a published reference root. Freshness depends on the snapshot distribution frequency.
-- The `subjectDN` contains a secret unique identifier not publicly available; if `subjectDN` were guessable, an adversary could compute nullifiers for targeted users.
+- The nullifier is derived from the card's RSA signature, which requires possession of the card's private key. An adversary cannot compute nullifiers without the card, even if the `subjectDN` is known.
+- Per-session `pk_blind` provides cross-session unlinkability. The blinding value MUST be fresh 248-bit randomness for each session. Reusing `pk_blind` across sessions would allow the verifier to link presentations.
+- A future version SHOULD add a domain-separation tag to the nullifier's signed message to prevent cross-protocol correlation when the same card key is used by multiple ZK protocols.
 
 ## Privacy and Security Best Practices
 
@@ -397,6 +505,9 @@ This version does not include device binding. Certificate sharing across devices
 
 **Revocation latency (v0.1)**
 The revocation SMT snapshot update is not real-time. The window between CRL publication and snapshot rebuild depends on the update mechanism (manual, automated). During this window, revoked certificates remain usable.
+
+**Dual-credential nullifier divergence (v0.1)**
+Holders of both a physical card and a digital credential have different RSA key pairs per credential. Since the nullifier is derived from the card's RSA signature, each credential produces a different nullifier, allowing one verification per credential type. This is a known, accepted trade-off.
 
 **On-chain verification (v0.1)**
 On-chain verification is deferred for this version. See [On-Chain Verification Status](#on-chain-verification-status) for the full rationale.

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -163,7 +163,7 @@ Implementations MUST:
 1. Obtain `challenge`, `app_id`, and the current `revocation_root` from the verifier context.
 2. Download the SMT snapshot and generate the revocation non-inclusion witness locally (see [Witness Retrieval](#witness-retrieval)). Verify that the locally computed root matches the published `revocation_root`.
 3. Generate fresh `pk_blind` (248-bit randomness) for this session.
-4. Sign the TBS data (containing `app_id || subjectDN`) with the card's RSA key to obtain `σ_device`.
+4. Sign the TBS data (containing `app_id`) with the card's RSA key to obtain `σ_device`.
 5. Construct CertChain circuit inputs from the certificate `S`, issuer CA signature `σ`, user public key, `pk_blind`, and the locally generated revocation witness.
 6. Construct DeviceSig circuit inputs from the TBS data, `σ_device`, user public key, `pk_blind`, and the `challenge`.
 7. Generate proofs for both circuits (see [Circuit Design](#circuit-design)).

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -105,7 +105,7 @@ The protocol MUST output a deterministic nullifier to prevent duplicate verifica
 The nullifier is derived from the card's RSA signature over an application-bound message:
 
 ```
-nullifier := Poseidon( RSA_Sign_sk(app_id || subjectDN) )
+nullifier := Poseidon( RSA_Sign_sk(app_id) )
 ```
 
 Where:

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -120,7 +120,7 @@ Because the nullifier derivation requires the card's private key, an adversary c
 
 Each platform MUST use a unique `app_id`.
 
-A future version SHOULD add a domain-separation tag to the signed message (e.g., `"zkID-nullifier-v1" || app_id || subjectDN`) to prevent cross-protocol nullifier correlation when the same card key is used across multiple ZK protocols.
+A future version SHOULD add a domain-separation tag to the signed message (e.g., `"zkID-nullifier-v1" || app_id`) to prevent cross-protocol nullifier correlation when the same card key is used across multiple ZK protocols.
 
 ## Cryptographic Primitives
 

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -389,7 +389,7 @@ Error responses MUST include:
 
 ## Certificate Renewal
 
-The nullifier is derived from the card's RSA signature over `app_id || subjectDN`. If certificate renewal issues a new RSA key pair, the nullifier will change (different signing key produces a different signature). Therefore a user MAY be able to verify again after renewal if the renewal generates a new key pair.
+The nullifier is derived from the card's RSA signature over `app_id`. If certificate renewal issues a new RSA key pair, the nullifier will change (different signing key produces a different signature). Therefore a user MAY be able to verify again after renewal if the renewal generates a new key pair.
 
 If the renewal retains the same key pair and `subjectDN`, the nullifier remains stable.
 

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -28,7 +28,7 @@ This specification defines a privacy-preserving protocol that allows a user to p
 
 The protocol prevents duplicate verification via a deterministic nullifier. Off-chain verification is the deployment mode for this version. On-chain verification was evaluated and is deferred (see [On-Chain Verification Status](#on-chain-verification-status)).
 
-The proof generation pipeline builds on OpenAC ([paper](https://github.com/privacy-ethereum/zkID/blob/main/paper/zkID.pdf)), adopting a minimal profile: RSA certificate chain validation, nullifier-based duplicate prevention, SMT-based revocation, and per-session unlinkability via blinded key commitments. The proof pipeline is split into two linked sub-circuits — a CertChain circuit for credential verification and a DeviceSig circuit for session binding and nullifier derivation.
+The proof generation pipeline builds on OpenAC ([paper](https://github.com/privacy-ethereum/zkID/blob/main/paper/zkID.pdf)), adopting a minimal profile: X.509 certificate chain validation and proof-of-possession of the end-entity's private key, nullifier-based duplicate prevention, non-membership proof against the revocation list (currently a Sparse Merkle Tree; leanIMT+ is being evaluated for a future revision), and per-session blinded key commitments that link the two sub-circuits. The proof pipeline is split into two linked sub-circuits — a CertChain circuit for credential verification and a DeviceSig circuit for session binding and nullifier derivation.
 
 This version (v0.1) enforces one verification per certificate instance. If the certificate is periodically renewed and renewal modifies the certificate contents, the user MAY be able to verify again (known limitation).
 
@@ -46,10 +46,9 @@ Implementations MUST provide:
 
 ### 1. Certificate Model
 
-A certificate `S` is a structured message containing a subject distinguished name (`subjectDN`), a subject number (`sn`), attributes `m`, and an RSA signature `σ` over the TBS (To-Be-Signed) certificate data.
+A certificate `S` is an X.509 certificate containing a serial number (`sn`), attributes `m`, and an RSA signature `σ` over the TBS (To-Be-Signed) certificate data.
 
-- `subjectDN`: A secret unique identifier assigned by the issuing CA. Used for nullifier derivation.
-- `sn` (subject number): A distinct field from `subjectDN`, used as the key for revocation lookups. The `sn` does not directly reveal the prover's identity.
+- `sn` (serial number): The certificate's X.509 serial number, used as the key for revocation lookups. The `sn` does not directly reveal the prover's identity.
 
 The certificate MUST be issued by a trusted Certificate Authority (CA). The issuer's public key `PK_I` MUST be verifiable through a certificate chain rooted in one of:
 - hardcoded trusted CA root certificates (e.g., government root CA), or
@@ -68,7 +67,7 @@ The protocol MUST support certificate revocation via a **non-inclusion proof** a
 A revocation list is maintained as a **Sparse Merkle Tree (SMT)** where each leaf corresponds to a revoked certificate identifier:
 
 ```
-revoked_leaf := Poseidon( Encode(sn) )
+revoked_leaf := Poseidon(sn, 1, 1)   // Hash3(key, value, entryMark)
 ```
 
 A trusted party (e.g., the CA or a designated updater) MUST maintain and publish the full SMT, constructed from the CA's Certificate Revocation List (CRL) or an equivalent revocation feed. The published SMT state MUST be periodically rebuilt from the latest CRL. Only the SMT root (`revocation_root`) needs to be distributed for verification; the full tree state is distributed as a downloadable snapshot for client-side proof generation.
@@ -82,9 +81,7 @@ The client-side witness retrieval flow is:
 1. Download the compressed SMT snapshot to the local device.
 2. Import the snapshot into a local disk-backed SMT (e.g., SQLite).
 3. Generate the non-membership Merkle path (sibling hashes) for the prover's `sn` position locally.
-4. Verify that the locally computed `revocation_root` matches the published reference root.
-5. Use the locally generated Merkle path as the `revocation_witness` private input.
-6. Clean up local SMT data after proof generation.
+4. Use the locally generated Merkle path as the `revocation_witness` private input. The CertChain circuit enforces consistency by verifying the SMT non-inclusion proof against the `smtRoot` public input, so the verifier checks the root match — the prover does not need to perform a separate root-comparison step.
 
 The `sn` MUST NOT leave the prover's device during this process.
 
@@ -102,7 +99,7 @@ Verifiers MUST provide a 256-bit `challenge` value per verification attempt.
 
 The protocol MUST output a deterministic nullifier to prevent duplicate verification.
 
-The nullifier is derived from the card's RSA signature over an application-bound message:
+The nullifier is derived from the card's RSA signature over the application identifier:
 
 ```
 nullifier := Poseidon( RSA_Sign_sk(app_id) )
@@ -111,12 +108,11 @@ nullifier := Poseidon( RSA_Sign_sk(app_id) )
 Where:
 - `RSA_Sign_sk` is the card's RSA signing operation using the user's private key `sk` (PKCS#1 v1.5, which is deterministic — same key + same message = same signature),
 - `app_id` is a platform identifier (domain separator),
-- `subjectDN` is the subject distinguished name extracted from the certificate,
 - `Poseidon` is the Poseidon hash function (see [Cryptographic Primitives](#cryptographic-primitives)).
 
 The nullifier is computed in the DeviceSig circuit, not the CertChain circuit (see [Circuit Design](#circuit-design)).
 
-Because the nullifier derivation requires the card's private key, an adversary cannot compute nullifiers for targeted users even if the `subjectDN` is known. This prevents dictionary attacks against the nullifier.
+Because the nullifier derivation requires the card's private key, an adversary cannot compute nullifiers without possession of the card.
 
 Each platform MUST use a unique `app_id`.
 
@@ -160,11 +156,11 @@ On-chain verification is not supported in this version. See [On-Chain Verificati
 
 Implementations MUST:
 
-1. Obtain `challenge`, `app_id`, and the current `revocation_root` from the verifier context.
-2. Download the SMT snapshot and generate the revocation non-inclusion witness locally (see [Witness Retrieval](#witness-retrieval)). Verify that the locally computed root matches the published `revocation_root`.
+1. Obtain `challenge` and `app_id` from the verifier's challenge issuance endpoint and the current `revocation_root` from the verifier's revocation root status endpoint (see [Verifier API](#verifier-api)).
+2. Download the SMT snapshot and generate the revocation non-inclusion witness locally (see [Witness Retrieval](#witness-retrieval)).
 3. Generate fresh `pk_blind` (248-bit randomness) for this session.
 4. Sign the TBS data (containing `app_id`) with the card's RSA key to obtain `σ_device`.
-5. Construct CertChain circuit inputs from the certificate `S`, issuer CA signature `σ`, user public key, `pk_blind`, and the locally generated revocation witness.
+5. Construct CertChain circuit inputs from the issuer and user certificates, `pk_blind`, and the locally generated revocation witness.
 6. Construct DeviceSig circuit inputs from the TBS data, `σ_device`, user public key, `pk_blind`, and the `challenge`.
 7. Generate proofs for both circuits (see [Circuit Design](#circuit-design)).
 8. Submit both proofs and their public inputs to the verifier.
@@ -188,11 +184,14 @@ pk_commit := ChunkedPoseidonP256(user_pk_limbs[0..k] || pk_blind)
 
 Where:
 - `user_pk_limbs` are the limbs of the user's RSA-2048 public key (`k=17` limbs),
-- `pk_blind` is fresh 248-bit randomness generated per session.
+- `pk_blind` is fresh 248-bit randomness generated per session. 248 bits leaves headroom below the secq256r1 scalar field size and avoids overflow in `pk_commit` derivation.
 
 Both circuits MUST compute `pk_commit` identically. The verifier MUST assert that the `pk_commit` from the CertChain proof equals the `pk_commit` from the DeviceSig proof.
 
-`pk_blind` provides cross-session unlinkability: even for the same user key, `pk_commit` differs across sessions, preventing the verifier from linking separate verification attempts.
+`pk_blind` plays two roles:
+
+1. **Cross-circuit linkage of the same user key.** The CertChain circuit and the DeviceSig circuit both consume the same `pk_blind` to compute identical `pk_commit` values, proving that both proofs reference the same underlying user public key without revealing the key itself.
+2. **Blinding of the user public key.** Even if the user's RSA public key were leaked, an adversary could not reproduce `pk_commit` for a given session without also possessing the per-session `pk_blind`. The blinding value MUST be fresh per session; reusing `pk_blind` across sessions would allow the verifier to link presentations.
 
 ### Valid Configurations
 
@@ -207,13 +206,12 @@ The DeviceSig circuit is always RSA-2048 because user keys are always RSA-2048.
 
 #### Private Inputs
 
-- `S`: Certificate message (certificate data).
-- `σ`: RSA signature over the TBS (To-Be-Signed) data from the issuer CA.
-- `subjectDN`: Subject distinguished name extracted from `S`.
-- `sn`: Subject number extracted from `S`, used for revocation lookup.
-- `PK_cert`: Public key extracted from the end-entity certificate.
+- `issuer_cert`: The issuer CA certificate (full structure, including the signature `σ` over the TBS certificate data and the issuer modulus).
+- `user_cert`: The end-entity certificate (full structure, including the user's public key and serial number).
 - `pk_blind`: Fresh 248-bit randomness for `pk_commit` blinding.
 - `revocation_witness`: SMT non-inclusion proof (Merkle path of sibling hashes) for the prover's `sn`, generated locally from a downloaded SMT snapshot (see [Witness Retrieval](#witness-retrieval)).
+
+The user serial number `sn` and user public-key limbs `user_pk_limbs` are extracted from `user_cert` in-circuit. The issuer modulus and issuer signature are extracted from `issuer_cert` in-circuit.
 
 #### Public Inputs
 
@@ -230,32 +228,26 @@ The CertChain circuit MUST enforce:
    Confirm that the end-entity certificate was issued by a trusted CA:
 
    ```
-   isValid := RSA_Verify(issuer_modulus, TBS(S), σ)
+   isValid := RSA_Verify(issuer_modulus, TBS(user_cert), σ)
    assert(isValid == 1)
    ```
 
-2. **Subject DN extraction**
+2. **Serial number extraction**
 
    ```
-   subjectDN := ExtractSubjectDN(S)
+   sn := ExtractSerialNumber(user_cert)
    ```
 
-3. **Serial number extraction**
-
-   ```
-   sn := ExtractSerialNumber(S)
-   ```
-
-4. **Revocation non-inclusion**
+3. **Non-inclusion of the revocation list**
 
    Prove the certificate has not been revoked:
 
    ```
-   revoked_id := Poseidon( Encode(sn) )
+   revoked_id := Poseidon(sn, 1, 1)   // Hash3(key, value, entryMark)
    assert( SMT_NonInclusion(smtRoot, revoked_id, revocation_witness) == 1 )
    ```
 
-5. **pk_commit computation**
+4. **pk_commit computation**
 
    ```
    pk_commit := ChunkedPoseidonP256(user_pk_limbs || pk_blind)
@@ -274,7 +266,7 @@ The CertChain circuit MUST enforce:
 
 - `pk_commit`: Blinded commitment to the user's public key (must match CertChain).
 - `nullifier: bytes32`: Derived from the card's RSA signature.
-- `app_id_packed`: Platform identifier packed as a single field element.
+- `app_id_packed`: Platform identifier (`app_id`) packed as a single field element. The specific `app_id` value is platform-defined; each platform MUST use a unique value (see [Nullifier](#4-nullifier)).
 - `challenge: bytes32`: Per-session challenge from the verifier.
 
 #### DeviceSig Operations
@@ -345,6 +337,92 @@ A minimal proof submission object SHOULD include:
 }
 ```
 
+## Verifier API
+
+This section specifies the network interface that conforming verifiers SHOULD expose so that wallets, SDKs, and relying parties can integrate against a stable contract independent of any specific verifier implementation.
+
+The Verifier API does not modify the cryptographic protocol or circuit relations defined in [Specification](#specification). It defines the wire-level operations needed to deliver challenges to provers, accept proof submissions, expose deployment state, and report errors.
+
+This section describes the 2-party deployment topology (relying party ↔ verifier). Other deployment topologies (e.g., 3-party flows where a wallet mediates between a merchant and the verifier, as in 6/ZK-AGE-ELIGIBILITY) are out of scope for this version. Where applicable, the term `challenge` used here corresponds to the verifier-issued nonce used elsewhere in OpenAC-based flows.
+
+### Operations
+
+Conforming verifiers MUST support the semantic operations listed below. RECOMMENDED URL paths are provided for HTTP/JSON deployments; gRPC and other transports MAY use equivalent method names.
+
+#### Challenge Issuance
+
+The verifier MUST expose a challenge issuance operation.
+
+- RECOMMENDED HTTP endpoint: `POST /challenge`
+- Request body: MAY be empty, or MAY include relying-party context fields (e.g., `app_id`) when a verifier serves multiple applications.
+- Response body MUST include:
+  - `challenge`: a 256-bit value, encoded consistently across the deployment (e.g., decimal field element, base64, or hex)
+  - `app_id`: the verifier's configured platform identifier for this verification context, returned so the prover can confirm the value used to construct the proof matches what the verifier expects
+  - `expires_at`: timestamp after which the challenge MUST be rejected
+- Issued challenges MUST satisfy the freshness requirements in [Challenge (Anti-replay)](#3-challenge-anti-replay).
+
+#### Proof Submission
+
+The verifier MUST expose a linked proof submission operation that accepts the proof envelope defined in [Proof Output Format](#proof-output-format).
+
+- RECOMMENDED HTTP endpoint: `POST /link-verify`
+- Request body: the proof submission object specified in [Proof Output Format](#proof-output-format).
+- Response body MUST include:
+  - `decision`: one of `"pass"` or `"fail"`
+  - `error_code`: present when `decision == "fail"`; one of the canonical values listed under [Error Codes](#error-codes)
+  - `error_message`: human-readable supplementary message; SHOULD NOT contain raw proof bytes or other sensitive material
+- Response body MAY include:
+  - `verified_at`: timestamp at which verification was performed
+  - additional non-PII metadata required for relying-party operation
+- The verifier MUST perform every validation step required by [Proof Verification](#proof-verification) before returning `pass`.
+- The verifier MUST persist the submitted `nullifier` per the rules in [Nullifier Persistence](#nullifier-persistence) before returning `pass`.
+
+#### Status Queries
+
+Verifiers SHOULD expose read-only status endpoints so that provers can detect stale local state before submitting proofs:
+
+- Revocation root status: RECOMMENDED `GET /smt-root/status`. Response MUST include the current `smt_root` and SHOULD include an updated-at timestamp.
+- Issuer certificate status: RECOMMENDED `GET /issuer-cert/status`. Response MUST include an enumeration of the issuer CA modulus values currently accepted by this verifier (matching the verifier's CA allowlist per [Certificate Model](#1-certificate-model)).
+
+### Error Codes
+
+When `decision == "fail"`, verifiers MUST set `error_code` to one of the following canonical values:
+
+| Code | Meaning |
+| --- | --- |
+| `INVALID_PROOF` | One or both proofs failed cryptographic verification. |
+| `INVALID_CHALLENGE` | The submitted `challenge` does not match a challenge issued by this verifier. |
+| `EXPIRED_CHALLENGE` | The submitted `challenge` was issued by this verifier but has expired. |
+| `STALE_REVOCATION_ROOT` | The submitted `smt_root` does not match the verifier's current revocation root. |
+| `INVALID_APP_ID` | The submitted `app_id_packed` does not match this verifier's configured `app_id`. |
+| `PK_COMMIT_MISMATCH` | The `pk_commit` from the CertChain proof does not equal the `pk_commit` from the DeviceSig proof. |
+| `DUPLICATE_NULLIFIER` | The submitted `nullifier` has already been recorded for this `app_id`. |
+| `MALFORMED_REQUEST` | The submission body could not be parsed against the expected schema. |
+| `INTERNAL_ERROR` | The verifier encountered an internal failure unrelated to proof contents. |
+
+Additional implementation-defined error codes MAY be returned but MUST NOT collide with the canonical names above.
+
+### Nullifier Persistence
+
+To enforce the duplicate-verification rejection required by [Proof Verification](#proof-verification), verifiers MUST implement a nullifier store satisfying:
+
+- **Atomic insert-if-absent**: a successful proof submission MUST atomically record `(app_id, nullifier)` such that concurrent submissions of the same `(app_id, nullifier)` pair cannot both return `pass`.
+- **Query**: the verifier MUST be able to determine whether a given `(app_id, nullifier)` pair has been previously recorded.
+- **Durability**: recorded nullifiers MUST survive verifier process restarts and host failures appropriate to the deployment's availability requirements.
+- **Retention**: recorded nullifiers MUST be retained for at least the lifetime of the issuer's certificate validity policy. Implementations MAY retain longer.
+
+The choice of storage backend (SQL, key-value store, distributed log, etc.) is implementation-defined.
+
+### Authentication
+
+This version does not specify a verifier-to-relying-party authentication mechanism. Deployments MUST document the authentication model they rely on (e.g., mutual TLS, bearer tokens, IP allowlist, none). A future revision MAY standardize this.
+
+### Transport
+
+- HTTP/JSON over TLS is RECOMMENDED for general integration. Request and response bodies MUST be valid UTF-8 JSON conforming to the schemas defined above.
+- gRPC over TLS is OPTIONAL and provides equivalent semantic operations. When gRPC is offered, method names SHOULD parallel the HTTP endpoint names (e.g., `Challenge`, `LinkVerify`, `SmtRootStatus`, `IssuerCertStatus`).
+- Other transports (e.g., WebSocket, message queue) MAY be implemented provided the semantic operations and error contract above are preserved.
+
 ## Proof Verification
 
 ### Verifier MUST
@@ -356,7 +434,7 @@ A minimal proof submission object SHOULD include:
 - Validate challenge freshness (not expired).
 - Validate that `smt_root` matches the latest known revocation tree root (from the CA's CRL or a trusted updater).
 - Check whether the nullifier has already been used and reject duplicates.
-- Persist nullifier state durably (i.e., nullifier rejection MUST survive verifier restarts).
+- Persist nullifier state durably (i.e., nullifier rejection MUST survive verifier restarts). See [Nullifier Persistence](#nullifier-persistence) for the atomicity, query, durability, and retention rules.
 
 ### Verifier MAY
 
@@ -376,7 +454,7 @@ Implementations SHOULD handle:
 
 Error responses MUST include:
 
-- Error code
+- Error code (set per the canonical taxonomy in [Error Codes](#error-codes))
 - Error message
 - Error details (when available)
 
@@ -391,7 +469,7 @@ Error responses MUST include:
 
 The nullifier is derived from the card's RSA signature over `app_id`. If certificate renewal issues a new RSA key pair, the nullifier will change (different signing key produces a different signature). Therefore a user MAY be able to verify again after renewal if the renewal generates a new key pair.
 
-If the renewal retains the same key pair and `subjectDN`, the nullifier remains stable.
+If the renewal retains the same key pair, the nullifier remains stable.
 
 ## On-Chain Verification Status
 
@@ -466,8 +544,8 @@ The protocol assumes:
 - Collision resistance of SHA-256 (for TBS hashing) and Poseidon over secq256r1 (for nullifier derivation, pk_commit computation, and revocation leaf computation).
 - Correct and unique domain separation via `app_id`.
 - Correct canonical encoding via `Encode()` (base64, standard alphabet, with padding).
-- Freshness of the revocation SMT snapshot (i.e., the snapshot reflects the latest CRL published by the CA). The prover downloads the snapshot locally and verifies the computed root against a published reference root. Freshness depends on the snapshot distribution frequency.
-- The nullifier is derived from the card's RSA signature, which requires possession of the card's private key. An adversary cannot compute nullifiers without the card, even if the `subjectDN` is known.
+- Freshness of the revocation SMT snapshot (i.e., the snapshot reflects the latest CRL published by the CA). The CertChain circuit verifies the SMT non-inclusion proof against the `smtRoot` public input, so the verifier checks the root matches the latest published value. Freshness depends on the snapshot distribution frequency.
+- The nullifier is derived from the card's RSA signature, which requires possession of the card's private key. An adversary cannot compute nullifiers without possession of the card's private key.
 - Per-session `pk_blind` provides cross-session unlinkability. The blinding value MUST be fresh 248-bit randomness for each session. Reusing `pk_blind` across sessions would allow the verifier to link presentations.
 - A future version SHOULD add a domain-separation tag to the nullifier's signed message to prevent cross-protocol correlation when the same card key is used by multiple ZK protocols.
 
@@ -498,7 +576,7 @@ There is an inherent delay between a CA revoking a certificate (publishing a new
 ## Known Limitations
 
 **Renewal limitation (v0.1)**
-If certificate renewal changes `subjectDN`, a user MAY verify again.
+If certificate renewal issues a new RSA key pair, a user MAY verify again (the nullifier changes because the signing key changed).
 
 **Certificate sharing (v0.1)**
 This version does not include device binding. Certificate sharing across devices is not cryptographically prevented.
@@ -511,6 +589,9 @@ Holders of both a physical card and a digital credential have different RSA key 
 
 **On-chain verification (v0.1)**
 On-chain verification is deferred for this version. See [On-Chain Verification Status](#on-chain-verification-status) for the full rationale.
+
+**Server-held signing keys (v0.1)**
+Some deployments (e.g., the TW FidO mobile app) hold the user's RSA signing key on a sign server rather than on a tamper-resistant card under the user's sole control. In such deployments, the security guarantee "an adversary cannot compute nullifiers without possession of the card's private key" is weakened to "an adversary cannot compute nullifiers without access to the sign server's signing pathway." Deployments using server-held keys MUST document this trust assumption. See [Deployment Profiles](#deployment-profiles) for the per-deployment characteristics.
 
 # Implementation Notes
 
@@ -530,6 +611,26 @@ Implementations SHOULD provide test vectors for:
 - nullifier derivation,
 - signature verification inputs,
 - SMT non-inclusion proof generation and verification.
+
+## Deployment Profiles
+
+The protocol has been deployed against two distinct credential profiles in the MOICA / TW ecosystem. They share the same cryptographic primitives (RSA-2048/4096 chains, Poseidon, Spartan2/Hyrax) but differ in how the user's signing key is held and accessed.
+
+- **Physical IC card (Citizen Digital Certificate).** The user's RSA-2048 private key is held on a tamper-resistant smartcard issued by MOICA. Signing operations require the card to be physically present and unlocked with a PIN. Proof generation runs on the user's device (mobile app or desktop with a card reader). This profile satisfies the spec's "card private key required" guarantee directly.
+
+- **TW FidO (mobile app).** The user's RSA private key is provisioned to and held on a remote sign server operated by the issuer. The mobile app authenticates the user (typically with FIDO2 biometric / device key) to the sign server, which then performs the RSA signing operation server-side. Compared to the physical IC card profile, the trust boundary is moved from "user's tamper-resistant hardware" to "issuer's sign server." See the §Known Limitations entry on Server-held signing keys.
+
+Other deployments MUST document their key-storage model and the resulting threat-model assumptions.
+
+## Verifier Implementations
+
+Reference verifier implementations are available across multiple deployment surfaces:
+
+- **Production HTTP / gRPC server**: [zkmopro/go-zkid-verifier](https://github.com/zkmopro/go-zkid-verifier) — Go-native verifier with a CGO FFI bridge to a Rust cryptographic backend. Exposes endpoints for challenge issuance (`POST /challenge`), linked proof verification (`POST /link-verify`), revocation root status (`GET /smt-root/status`), and issuer certificate cache state (`GET /issuer-cert/status`), with gRPC equivalents on a parallel port.
+- **Portable WASM verifier**: [zkmopro/zkID/wallet-unit-poc/spartan2-wasm](https://github.com/zkmopro/zkID/tree/main/wallet-unit-poc/spartan2-wasm) — Rust-to-WASM verifier suitable for browser and mobile contexts. Exposes `verify(proof_bytes, vk_bytes)` and `link_verify(cert_pubs, device_pubs)` for cross-proof `pk_commit` matching.
+- **Verifier SDK for relying parties**: [zkmopro/zkID/wallet-unit-poc/openac-sdk](https://github.com/zkmopro/zkID/tree/main/wallet-unit-poc/openac-sdk) — TypeScript SDK that validates proofs and extracts public values for relying-party integration.
+- **Browser verifier reference**: [zkmopro/zkID/wallet-unit-poc/web](https://github.com/zkmopro/zkID/tree/main/wallet-unit-poc/web) — Vite-based browser frontend demonstrating end-to-end verification.
+- **Arbitrum Stylus on-chain verifier (proof of concept)**: deployed on Arbitrum Sepolia at [`0xfcd5fc2da39f4dc822835f99b5a70d12e32b24fd`](https://sepolia.arbiscan.io/address/0xfcd5fc2da39f4dc822835f99b5a70d12e32b24fd#code). See [On-Chain Verification Status](#on-chain-verification-status) for current status and known blockers.
 
 ## User Experience Guidelines
 
@@ -593,7 +694,7 @@ When the verification flow requires PIN entry (e.g., for smartcard-based certifi
 
 ## Certificate
 
-A CA-signed certificate `S` containing a subject distinguished name (`subjectDN`), attributes `m`, and an RSA signature `σ`.
+A CA-signed X.509 certificate `S` containing a serial number (`sn`), attributes `m`, and an RSA signature `σ`.
 
 ## Nullifier
 
@@ -607,9 +708,9 @@ A verifier-provided nonce bound to the proof to prevent replay.
 
 A set of certificate identifiers that have been invalidated by the issuing CA, represented as a Sparse Merkle Tree for ZK-compatible non-inclusion proofs.
 
-## Subject Number (`sn`)
+## Serial Number (`sn`)
 
-A certificate field distinct from `subjectDN`, used as the key for revocation lookups. The `sn` does not directly reveal the prover's identity and is used locally to generate a non-inclusion witness from a downloaded SMT snapshot.
+The X.509 serial number field of a certificate, used as the key for revocation lookups. The `sn` does not directly reveal the prover's identity and is used locally to generate a non-inclusion witness from a downloaded SMT snapshot.
 
 ## Sparse Merkle Tree (SMT)
 

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -127,7 +127,7 @@ A future version SHOULD add a domain-separation tag to the signed message (e.g.,
 This specification defines:
 
 - Hash function (data integrity): `SHA-256` for certificate TBS data hashing.
-- Hash function (nullifier, pk_commit): `Poseidon` hash over the secq256r1 scalar field, a ZK-friendly hash function optimized for arithmetic circuits. For hashing more than 3 field elements, implementations use `ChunkedPoseidonP256(N)` — a sponge construction wrapping `PoseidonP256(2)` that processes N field elements in chunks.
+- Hash function (nullifier, pk_commit): `Poseidon` hash over the secq256r1 scalar field, a ZK-friendly hash function optimized for arithmetic circuits. For hashing more than 16 field elements, implementations use `ChunkedPoseidonP256(N)` — a sponge construction wrapping `PoseidonP256(2)` that processes N field elements in chunks.
 - Signature verification: `RSA_Verify(PK, msg, σ) -> {0,1}` — RSA signature verification over SHA-256 hashed TBS data.
 - Sparse Merkle Tree non-inclusion: `SMT_NonInclusion(root, leaf, proof) -> {0,1}` — verifies that `leaf` is **not** present in the SMT committed to by `root` (see [PSE: Revocation in zkID](https://pse.dev/blog/revocation-in-zkid-merkle-tree-based-approaches)).
 - Encoding: `Encode()` is a deterministic canonical encoding function using base64 encoding. All implementations MUST use the same base64 encoding variant (standard alphabet, with padding) to ensure consistent nullifier derivation across verifiers.

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -26,7 +26,7 @@ interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 This specification defines a privacy-preserving protocol that allows a user to prove possession of a valid issuer-signed certificate and obtain a one-time "verified human" status on an online forum without disclosing certificate attributes.
 
-The protocol prevents duplicate verification via a deterministic nullifier. Off-chain verification is the default deployment mode; on-chain verification via a smart contract registry serves as a fallback. Both modes MUST be supported by a conforming deployment.
+The protocol prevents duplicate verification via a deterministic nullifier. Off-chain verification is the deployment mode for this version. On-chain verification was evaluated and is deferred (see [On-Chain Verification Status](#on-chain-verification-status)).
 
 The proof generation pipeline builds on OpenAC ([paper](https://github.com/privacy-ethereum/zkID/blob/main/paper/zkID.pdf)), adopting a minimal profile: RSA certificate chain validation, nullifier-based duplicate prevention, and SMT-based revocation. Features such as unlinkability and device binding are not in scope for this version but MAY be incorporated in future revisions.
 
@@ -52,9 +52,8 @@ A certificate `S` is a structured message containing a subject distinguished nam
 - `sn` (subject number): A distinct field from `subjectDN`, used as the key for revocation lookups. The `sn` does not directly reveal the prover's identity.
 
 The certificate MUST be issued by a trusted Certificate Authority (CA). The issuer's public key `PK_I` MUST be verifiable through a certificate chain rooted in one of:
-- hardcoded trusted CA root certificates (e.g., government root CA),
-- a platform-managed CA allowlist, or
-- an on-chain CA key registry (see [On-Chain Registry Variant](#on-chain-registry-variant)).
+- hardcoded trusted CA root certificates (e.g., government root CA), or
+- a platform-managed CA allowlist.
 
 The certificate chain consists of:
 - `PK_CA`: The public key from the intermediate CA certificate, which signs the end-entity certificate.
@@ -72,21 +71,24 @@ A revocation list is maintained as a **Sparse Merkle Tree (SMT)** where each lea
 revoked_leaf := Poseidon( Encode(sn) )
 ```
 
-The verifier maintains the full SMT off-chain, constructed from the CA's Certificate Revocation List (CRL) or an equivalent revocation feed. The verifier MUST periodically fetch the latest CRL from the CA or a trusted updater and rebuild the SMT accordingly. Only the SMT root (`revocation_root`) is stored on-chain in a smart contract (or distributed off-chain by the CA).
-
-The prover trusts that the verifier keeps the revocation tree up to date. This trust assumption is documented in [Security Considerations](#revocation-freshness).
+A trusted party (e.g., the CA or a designated updater) MUST maintain and publish the full SMT, constructed from the CA's Certificate Revocation List (CRL) or an equivalent revocation feed. The published SMT state MUST be periodically rebuilt from the latest CRL. Only the SMT root (`revocation_root`) needs to be distributed for verification; the full tree state is distributed as a downloadable snapshot for client-side proof generation.
 
 #### Witness Retrieval
 
-To obtain a revocation witness, the prover queries the verifier's revocation service with their subject number (`sn`). The service returns:
-- the Merkle path (sibling hashes) for the `sn` position in the SMT, and
-- the current `revocation_root`.
+To preserve privacy, the prover MUST generate the revocation non-inclusion witness locally. The prover MUST NOT send their `sn` to a remote service for witness retrieval.
 
-The prover uses this Merkle path as the `revocation_witness` private input to prove non-inclusion of their `sn` in the revocation tree.
+The client-side witness retrieval flow is:
 
-Implementations MUST support at least one of:
-- an off-chain revocation root distributed by the CA (e.g., derived from a CRL),
-- an on-chain revocation root stored in a smart contract (see [On-Chain Registry Variant](#on-chain-registry-variant)).
+1. Download the compressed SMT snapshot to the local device.
+2. Import the snapshot into a local disk-backed SMT (e.g., SQLite).
+3. Generate the non-membership Merkle path (sibling hashes) for the prover's `sn` position locally.
+4. Verify that the locally computed `revocation_root` matches the published reference root.
+5. Use the locally generated Merkle path as the `revocation_witness` private input.
+6. Clean up local SMT data after proof generation.
+
+The `sn` MUST NOT leave the prover's device during this process.
+
+Implementations MUST support an off-chain revocation root distributed by the CA or a trusted updater (e.g., derived from a CRL). The snapshot distribution mechanism is implementation-defined (e.g., CDN, IPFS, or a public repository).
 
 ### 3. Challenge (Anti-replay)
 
@@ -141,16 +143,17 @@ Concatenation MUST be length-prefixed (e.g., `len(x)||x||len(y)||y||...`) to avo
 
 ### Proving System
 
-- **Off-chain (default)**: Spartan2 with Hyrax polynomial commitment scheme. This is a transparent proving system (no trusted setup required).
-- **On-chain (fallback)**: Groth16. The target curve is under development; candidates include curves compatible with OpenAC (e.g., secp256r1). Groth16 requires a trusted setup; implementations MUST document the ceremony used.
+- Spartan2 with Hyrax polynomial commitment scheme. This is a transparent proving system (no trusted setup required).
+
+On-chain verification is not supported in this version. See [On-Chain Verification Status](#on-chain-verification-status) for the research summary and rationale.
 
 ## Protocol Flow
 
 Implementations MUST:
 
 1. Obtain `challenge`, `app_id`, and the current `revocation_root` from the verifier context.
-2. Query the verifier's revocation service with the prover's `sn` (subject number) to obtain the SMT Merkle path (sibling hashes) and current `revocation_root`. This Merkle path serves as the non-inclusion witness.
-3. Construct circuit inputs from the certificate `S`, RSA signature `σ`, trusted CA public keys, and the revocation witness.
+2. Download the SMT snapshot and generate the revocation non-inclusion witness locally (see [Witness Retrieval](#witness-retrieval)). Verify that the locally computed root matches the published `revocation_root`.
+3. Construct circuit inputs from the certificate `S`, RSA signature `σ`, trusted CA public keys, and the locally generated revocation witness.
 4. Generate a proof for the statement in [Circuit Design](#circuit-design).
 5. Submit the proof and public inputs to the verifier.
 
@@ -163,7 +166,7 @@ Implementations MUST:
 - `subjectDN`: Subject distinguished name extracted from `S`.
 - `sn`: Subject number extracted from `S`, used for revocation lookup.
 - `PK_cert`: Public key extracted from the end-entity certificate, used to verify the certificate was issued by the intermediate CA (`PK_CA`).
-- `revocation_witness`: SMT non-inclusion proof (Merkle path of sibling hashes) for the prover's `sn`, obtained from the verifier's revocation service.
+- `revocation_witness`: SMT non-inclusion proof (Merkle path of sibling hashes) for the prover's `sn`, generated locally from a downloaded SMT snapshot (see [Witness Retrieval](#witness-retrieval)).
 
 ### Public Inputs
 
@@ -239,11 +242,9 @@ A minimal proof object SHOULD include:
 - Validate the zero-knowledge proof against the public inputs.
 - Validate challenge freshness (not expired).
 - Enforce `app_id` matches the expected policy for the verification endpoint.
-- Validate that `revocation_root` matches the latest known revocation tree root (from the CA's CRL or an on-chain registry).
-
-### Verifier SHOULD
-
+- Validate that `revocation_root` matches the latest known revocation tree root (from the CA's CRL or a trusted updater).
 - Check whether the nullifier has already been used and reject duplicates.
+- Persist nullifier state durably (i.e., nullifier rejection MUST survive verifier restarts).
 
 ### Verifier MAY
 
@@ -286,34 +287,67 @@ A future version MAY derive nullifiers from a renewal-stable holder secret:
 nullifier := Poseidon( Encode(app_id || holder_secret) )
 ```
 
-## On-Chain Registry Variant
+## On-Chain Verification Status
 
-In the on-chain verification mode, a smart contract MAY act as the verifier and registry.
+On-chain verification was a design goal for this protocol (trustless nullifier registry, public verifiability). Extensive research and implementation work was conducted to evaluate feasibility. This section documents the findings and the rationale for deferring on-chain verification in this version.
 
-A contract MUST maintain:
+OpenAC has three core properties that MUST NOT be compromised:
 
-```
-mapping(bytes32 => bool) nullifierUsed
-```
+1. **Rerandomizable proofs** — required for unlinkability across presentations.
+2. **Transparent setup** — no trusted setup ceremony required.
+3. **Zero knowledge** — no credential attributes disclosed.
 
-A contract MAY additionally store:
-- `PK_I` (issuer public key) or a commitment to an issuer allowlist.
-- `revocationRoot` (`bytes32`): the current root of the revocation SMT, updated by a trusted updater role when the CA publishes a new CRL.
+The circuit size is ~2^20 constraints. The current design uses Spartan2 with Hyrax PCS over the T256 (secp256r1) curve. No EVM chain provides native T256 ecAdd/ecMul precompiles; RIP-7212 / EIP-7951 exposes only `ECDSA.verify(hash, r, s, x, y)`, which cannot be used for the arbitrary curve arithmetic that Hyrax and IPA require.
 
-Verification procedure:
+### Approaches Evaluated
 
-1. Verify the zero-knowledge proof.
-2. Ensure `nullifierUsed[nullifier] == false`.
-3. Set `nullifierUsed[nullifier] = true`.
-4. Emit an event:
+**1. Native Rust Verifier.** A self-contained Spartan2 verifier was built in Rust, independent of any external proving infrastructure. This serves as the foundation for off-chain verification and was used to validate subsequent on-chain approaches.
 
-```
-VerificationRegistered(nullifier, app_id)
-```
+**2. SP1 Wrapper.** The native verifier was wrapped inside SP1 to generate a succinct proof of verification. This direction was abandoned due to: (a) no T256 precompiles available in SP1, (b) prohibitive credit cost (~44 credits per proof), and (c) no provers accepting jobs at the required resource limits. Cost scales proportionally with complexity, making this economically unviable.
 
-No certificate attributes MUST be stored on-chain.
+**3. L2 Landscape Investigation.** All major L2s were surveyed for P-256 curve arithmetic support:
 
-Implementations MUST NOT store proofs on-chain for later reuse. Each verification MUST generate a fresh proof bound to a new challenge.
+| Chain | RIP-7212 (Sig Verify) | P-256 ecAdd/ecMul | Useful for Spartan2? |
+| --- | --- | --- | --- |
+| Arbitrum | Yes | No | Yes, via Stylus |
+| Optimism/Base | Yes | No | No |
+| zkSync Era | Yes | No | No |
+| Polygon PoS | Yes | No | No |
+| Scroll/Linea | Partial | No | No |
+
+No L2 currently provides the general-purpose P-256 curve arithmetic required. The only viable path is Arbitrum Stylus, which runs a WASM VM alongside the EVM with ~10–100x cheaper compute for cryptographic operations.
+
+**4. Groth16 with the same R1CS circuits.** Reuse existing circuits, add a per-circuit trusted setup. Cheapest on-chain cost (~$0.003), but breaks transparent setup.
+
+**5. Spartan2 + SPARK (native Solidity verifier).** SPARK preprocessing eliminates matrix storage but barely reduces per-verification gas (~3.7% savings). Estimated cost: ~200M gas on Arbitrum (~$20) for 2^20 constraints. Prohibitively expensive because every T256 curve operation runs as Solidity bytecode.
+
+**6. Spartan2 + SPARK + WHIR.** Replace Hyrax PCS with WHIR (hash-based PCS). Cheaper verification (~$0.03–$0.93 batched), but WHIR is not additively homomorphic — breaks rerandomizable proofs.
+
+**7. Spartan2 → Groth16 wrapper.** Verify the Spartan proof inside a Groth16 circuit. Cheap on-chain verification, but reintroduces trusted setup and adds 30–120s prover overhead.
+
+**8. Spartan2 + KZG.** Replace Hyrax with KZG (e.g., HyperKZG). Cheap on-chain verification (~$0.01–$0.05), preserves rerandomization and ZK, but requires trusted setup / universal SRS.
+
+**9. Arbitrum Stylus Verifier (Rust → WASM).** A fully self-contained Spartan2 verifier was built targeting Stylus with custom T256 field and curve arithmetic, no external crypto dependencies, compiled to WASM, and deployed on Arbitrum Sepolia ([0xfcd5fc2da39f4dc822835f99b5a70d12e32b24fd](https://sepolia.arbiscan.io/address/0xfcd5fc2da39f4dc822835f99b5a70d12e32b24fd#code)). This preserves all three core properties. However, it is currently blocked: Stylus caps contracts at 24 KB brotli-compressed (current build is ~349 KB uncompressed), and RPC clients reject the ~100 KB calldata required for proof submission.
+
+### Summary
+
+| Option | Transparent Setup | Rerandomizable | ZK | On-Chain Cost | Status |
+| --- | --- | --- | --- | --- | --- |
+| Groth16 | No | Yes | Yes | ~$0.003 | Breaks transparent setup |
+| Spartan2 + SPARK (Solidity) | Yes | Yes | Yes | ~$20 | Prohibitively expensive |
+| Spartan2 + SPARK + WHIR | Yes | No | Yes | ~$0.03–$0.93 | Breaks rerandomization |
+| Spartan2 → Groth16 wrapper | No | Yes | Yes | ~$0.003 | Breaks transparent setup |
+| Spartan2 + KZG | No | Yes | Yes | ~$0.01–$0.05 | Breaks transparent setup |
+| SP1 wrapper | Yes | Yes | Yes | N/A | Economically unviable |
+| Arbitrum Stylus | Yes | Yes | Yes | TBD | Blocked (contract size + calldata) |
+
+Only two options preserve all three core properties: Spartan2 + SPARK as a Solidity contract (prohibitively expensive) and Arbitrum Stylus (blocked on contract size and calldata limits). Every other option compromises at least one core property.
+
+### Conclusion
+
+On-chain verification is deferred for this version. Off-chain verification via Spartan2 with Hyrax PCS is the only conformance mode. A future version MAY revisit on-chain verification if the Stylus size blocker is resolved or if L2s add native P-256 curve arithmetic precompiles.
+
+For the full research details, see [Exploring Spartan2 Proofs for On-Chain Verification](https://github.com/zkmopro/zkID/blob/main/wallet-unit-poc/onchain-research.md).
 
 # Security Considerations
 
@@ -321,49 +355,37 @@ Implementations MUST NOT store proofs on-chain for later reuse. Each verificatio
 
 The protocol assumes:
 
-- The security of Spartan2 with Hyrax polynomial commitment scheme for off-chain verification (transparent setup — no trusted setup required), and the security of Groth16 for on-chain verification (requires trusted setup).
+- The security of Spartan2 with Hyrax polynomial commitment scheme (transparent setup — no trusted setup required).
 - The unforgeability of the RSA signature scheme (RSA-2048, PKCS#1 v1.5) used for certificate signing.
 - Collision resistance of SHA-256 (for TBS hashing) and Poseidon (for nullifier derivation and revocation leaf computation).
 - Correct and unique domain separation via `app_id`.
 - Correct canonical encoding via `Encode()` (base64, standard alphabet, with padding).
-- Freshness of the revocation SMT root (i.e., the root reflects the latest CRL published by the CA). The prover trusts that the verifier periodically fetches the CRL from the CA or a trusted updater and rebuilds the SMT accordingly.
+- Freshness of the revocation SMT snapshot (i.e., the snapshot reflects the latest CRL published by the CA). The prover downloads the snapshot locally and verifies the computed root against a published reference root. Freshness depends on the snapshot distribution frequency.
 - The `subjectDN` contains a secret unique identifier not publicly available; if `subjectDN` were guessable, an adversary could compute nullifiers for targeted users.
 
 ## Privacy and Security Best Practices
 
 - Proof generation SHOULD be performed on the user's device to reduce risk of certificate exposure.
+- Revocation witness generation MUST be performed locally on the user's device (see [Witness Retrieval](#witness-retrieval)).
 - Verifiers SHOULD minimize logging of public inputs, particularly nullifier, to reduce metadata retention.
-- Deployments using the on-chain registry SHOULD use relayers or transaction sponsorship to reduce linkage between proof submissions and wallet addresses.
 
 ## Linkability
 
-### Off-chain mode
+The nullifier is only visible to the forum platform verifier. Domain separation via `app_id` is REQUIRED to prevent cross-platform nullifier correlation.
 
-In off-chain mode, the nullifier is only visible to the forum platform verifier.
+## Revocation Witness Privacy
 
-### On-chain mode
+Client-side witness generation (see [Witness Retrieval](#witness-retrieval)) ensures that the prover's `sn` never leaves the device. This eliminates the metadata leakage risk present in server-side witness retrieval models, where the server would learn which `sn` is being checked.
 
-In on-chain mode:
-
-- Nullifiers are publicly observable.
-- Verification timing is public.
-- Transaction sender addresses may be linkable.
-- Domain separation via `app_id` is REQUIRED, but does not eliminate all metadata leakage.
-
-## Revocation Witness Retrieval Metadata
-
-When the prover queries the verifier's revocation service with their `sn` to obtain the non-inclusion witness, the verifier learns which `sn` is being checked. Since `sn` (subject number) does not directly reveal the prover's identity, this is considered an acceptable trade-off. However, deployments SHOULD be aware that repeated queries for the same `sn` could enable tracking.
-
-- Implementations MAY mitigate this by allowing batch retrieval of multiple SMT paths, or by using a privacy-preserving query mechanism.
-- The `sn` MUST NOT be logged alongside other identifying metadata (e.g., IP address, wallet address) by the revocation service.
+The prover downloads the full SMT snapshot, which is a public dataset derived from the CA's CRL. Downloading the snapshot does not reveal which certificate the prover holds.
 
 ## Revocation Freshness
 
-There is an inherent delay between a CA revoking a certificate (publishing a new CRL) and the revocation SMT root being updated. During this window, a revoked certificate can still produce valid proofs.
+There is an inherent delay between a CA revoking a certificate (publishing a new CRL), the SMT snapshot being rebuilt, and the prover downloading the updated snapshot. During this window, a revoked certificate can still produce valid proofs.
 
 - Verifiers SHOULD define a maximum acceptable `revocation_root` age.
-- On-chain deployments SHOULD emit a `RevocationRootUpdated(bytes32 newRoot, uint256 timestamp)` event to allow verifiers to track freshness.
-- Off-chain deployments SHOULD include the CRL publication timestamp alongside the `revocation_root`.
+- Snapshot publishers SHOULD include the CRL publication timestamp alongside the `revocation_root`.
+- Provers SHOULD download the latest available snapshot before each verification attempt.
 
 ## Known Limitations
 
@@ -374,17 +396,22 @@ If certificate renewal changes `subjectDN`, a user MAY verify again.
 This version does not include device binding. Certificate sharing across devices is not cryptographically prevented.
 
 **Revocation latency (v0.1)**
-The revocation SMT root update is not real-time. The window between CRL publication and root update depends on the update mechanism (manual, automated, on-chain oracle). During this window, revoked certificates remain usable.
+The revocation SMT snapshot update is not real-time. The window between CRL publication and snapshot rebuild depends on the update mechanism (manual, automated). During this window, revoked certificates remain usable.
+
+**On-chain verification (v0.1)**
+On-chain verification is deferred for this version. See [On-Chain Verification Status](#on-chain-verification-status) for the full rationale.
 
 # Implementation Notes
 
-A work-in-progress reference implementation is available at [zkID](https://github.com/zkmopro/zkID).
+A reference implementation is available at [zkID](https://github.com/zkmopro/zkID). Implementation tasks and progress are tracked at [ZK-based-Human-Verification](https://github.com/zkmopro/ZK-based-Human-Verification/issues).
 
-A reference implementation MAY:
+The current implementation includes:
 
-- generate proofs client-side (web or native app),
-- verify proofs off-chain in a backend, and/or
-- verify proofs in an EVM verifier contract for the on-chain registry variant.
+- **Mobile native bindings** (iOS / Android) via [mopro-ffi](https://github.com/zkmopro/mopro), enabling client-side proof generation on mobile devices.
+- **Mobile proof generation flow** integrated with the [Ptt-iOS](https://github.com/Ptt-official-app/Ptt-iOS) and [Ptt-Android](https://github.com/Ptt-official-app/Ptt-Android) forum apps.
+- **WASM browser proof generation** via mopro, enabling client-side proof generation in web apps.
+- **Server backend verification** with OpenAC verification logic ported from Rust to Go for the BBS server backend.
+- **Client-side SMT revocation** with local snapshot download and local non-inclusion proof generation (see [Witness Retrieval](#witness-retrieval)).
 
 Implementations SHOULD provide test vectors for:
 
@@ -402,6 +429,8 @@ Implementations SHOULD provide test vectors for:
 - [ZK Circuit Specification for Human Verification (prior art)](https://github.com/zkmopro/ZK-based-Human-Verification/issues/3)
 - [Revocation in zkID: Merkle Tree Based Approaches (PSE)](https://pse.dev/blog/revocation-in-zkid-merkle-tree-based-approaches)
 - [MOICA Certificate Revocation List](https://moica.nat.gov.tw/del.html)
+- [Client-side SMT proof generation for revocation privacy](https://github.com/zkmopro/ZK-based-Human-Verification/issues/16)
+- [Exploring Spartan2 Proofs for On-Chain Verification](https://github.com/zkmopro/zkID/blob/main/wallet-unit-poc/onchain-research.md)
 
 # Glossary
 
@@ -423,7 +452,7 @@ A set of certificate identifiers that have been invalidated by the issuing CA, r
 
 ## Subject Number (`sn`)
 
-A certificate field distinct from `subjectDN`, used as the key for revocation lookups. The `sn` does not directly reveal the prover's identity and is used to query the revocation service for a non-inclusion witness.
+A certificate field distinct from `subjectDN`, used as the key for revocation lookups. The `sn` does not directly reveal the prover's identity and is used locally to generate a non-inclusion witness from a downloaded SMT snapshot.
 
 ## Sparse Merkle Tree (SMT)
 

--- a/specs/5/README.md
+++ b/specs/5/README.md
@@ -521,7 +521,7 @@ The current implementation includes:
 - **Mobile native bindings** (iOS / Android) via [mopro-ffi](https://github.com/zkmopro/mopro), enabling client-side proof generation on mobile devices.
 - **Mobile proof generation flow** integrated with the [Ptt-iOS](https://github.com/Ptt-official-app/Ptt-iOS) and [Ptt-Android](https://github.com/Ptt-official-app/Ptt-Android) forum apps.
 - **WASM browser proof generation** via mopro, enabling client-side proof generation in web apps.
-- **Server backend verification** with OpenAC verification logic ported from Rust to Go for the BBS server backend.
+- **Server backend verification** with OpenAC verification logic ported from Rust to GO via FFI for the BBS server backend.
 - **Client-side SMT revocation** with local snapshot download and local non-inclusion proof generation (see [Witness Retrieval](#witness-retrieval)).
 
 Implementations SHOULD provide test vectors for:


### PR DESCRIPTION
## Summary

Updates spec 5 to reflect architectural decisions, implementation progress, and UX guidelines developed since the initial raw spec.

### Client-side SMT revocation
- Revocation witness retrieval moved from server-side (which leaked `sn` to the server) to fully client-side — prover downloads SMT snapshot locally, generates non-inclusion proof on-device, `sn` never leaves the device
- Ref: https://github.com/zkmopro/ZK-based-Human-Verification/issues/16

### On-chain verification deferred
- Replaced the On-Chain Registry Variant section with a detailed "On-Chain Verification Status" documenting 9 approaches evaluated (native Rust verifier, SP1 wrapper, L2 landscape survey, Groth16, SPARK, WHIR, KZG, Groth16 wrapper, Arbitrum Stylus) and why on-chain is not feasible for this version while preserving all three core properties (rerandomizable proofs, transparent setup, ZK)
- Ref: https://github.com/zkmopro/zkID/pull/58

### Nullifier durability
- Upgraded nullifier duplicate check from SHOULD to MUST, added durability requirement (must survive verifier restarts)

### Implementation notes
- Updated to reflect current status — mobile native bindings (iOS/Android), WASM browser proof generation, server backend verification (Rust→Go), web frontend, and client-side SMT revocation are all implemented

### User Experience Guidelines
- Added deployment-agnostic UX guidelines synthesized from the planned UI revision: privacy communication requirements, explicit consent before submission, technical detail separation, error handling UX, and PIN safety

## Test plan

- [ ] Review that all on-chain references are removed or point to the new On-Chain Verification Status section
- [ ] Review that Witness Retrieval section accurately reflects the client-side SMT architecture
- [ ] Verify internal links (`#on-chain-verification-status`, `#witness-retrieval`) resolve correctly
- [ ] Cross-check the on-chain research summary table against https://github.com/zkmopro/zkID/blob/main/wallet-unit-poc/onchain-research.md
- [ ] Review UX guidelines for completeness against the planned UI revision spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)